### PR TITLE
refactor: add transition and opacity to profile picture

### DIFF
--- a/src/sections/user/profile-header.tsx
+++ b/src/sections/user/profile-header.tsx
@@ -271,6 +271,8 @@ const ProfileHeader = ({ profile, children }: PropsWithChildren<ProfileHeaderPro
                 alt={profile?.handle?.localName ?? ''}
                 variant="rounded"
                 sx={{
+                  transition: '2s',
+                  opacity: (profile?.metadata?.picture as any)?.optimized?.uri ? 1: 0,
                   width: { xs: 64, md: 128 },
                   height: { xs: 64, md: 128 },
                   border: `solid 2px ${theme.palette.common.white}`,


### PR DESCRIPTION
- Added a 2-second transition to the profile picture for a smoother appearance.
- Implemented conditional opacity based on the presence of an optimized image URI.