### PR TITLE
refactor: filter testing profiles.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build analysis
-        run: npm run build
-
       - name: Run static analysis
         run: npm run lint
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    name: Release
+    name: Semver Release
     runs-on: ubuntu-latest
     concurrency: release
     environment: ${{ inputs.environment }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # WatchIt
+[![codecov](https://codecov.io/gh/WatchItDev/watchit-app/graph/badge.svg?token=LQSOJRMXIY)](https://codecov.io/gh/WatchItDev/watchit-app)
+
 WatchIt represents a transformative innovation in how audiovisual content is consumed and disseminated. Built on decentralized principles and powered by blockchain technology, the platform ensures secure, equitable, and dynamic content delivery through a network of distributed nodes. This architecture not only enhances system resilience but also fosters meaningful collaboration between creators and audiences, creating a vibrant and sustainable ecosystem.
 
 ![App Preview](image.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "watchit",
-  "version": "2.2.0-beta.25",
+  "version": "2.2.0-beta.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "watchit",
-      "version": "2.2.0-beta.25",
+      "version": "2.2.0-beta.26",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
         "@helia/unixfs": "^4.0.1",

--- a/src/components/login-modal/profile-select-view.tsx
+++ b/src/components/login-modal/profile-select-view.tsx
@@ -17,6 +17,7 @@ import { UserItem } from '../user-item';
 import LoadingScreen from '../loading-screen/loading-screen.tsx';
 import { notifyError } from '@notifications/internal-notifications.ts';
 import { ERRORS } from '@notifications/errors.ts';
+import {filterHiddenProfiles} from "@src/utils/profile.ts";
 // ----------------------------------------------------------------------
 
 interface ProfileSelectionProps {
@@ -54,7 +55,7 @@ export const ProfileSelectView: React.FC<ProfileSelectionProps> = ({
     (async () => {
       // @ts-ignore
       const results = await getProfiles({ where: { ownedBy: address as string } });
-      if (!results.isFailure()) setProfiles(results?.value as Profile[]);
+      if (!results.isFailure()) setProfiles(filterHiddenProfiles(results?.value) as Profile[]);
     })();
   }, [address]);
 

--- a/src/layouts/_common/searchbar/searchbar.tsx
+++ b/src/layouts/_common/searchbar/searchbar.tsx
@@ -23,6 +23,7 @@ import { useSearchPublications } from '@src/hooks/use-search-publications';
 import { CircularProgress } from '@mui/material';
 import { paths } from '@src/routes/paths.ts';
 import { useSelector } from 'react-redux';
+import {filterHiddenProfiles} from "@src/utils/profile.ts";
 
 function Searchbar() {
   const theme = useTheme();
@@ -63,8 +64,10 @@ function Searchbar() {
     setSearchQuery(event.target.value);
   }, []);
 
-  const { data: profiles, loading: loadingProfiles } = useSearchProfiles({ query: searchQuery });
+  const { data: results, loading: loadingProfiles } = useSearchProfiles({ query: searchQuery });
   const { publications, loading: loadingPublications } = useSearchPublications(searchQuery);
+
+  const profiles = filterHiddenProfiles(results)
 
   const dataFiltered = applyFilter({
     inputData: [],

--- a/src/sections/explore/view.tsx
+++ b/src/sections/explore/view.tsx
@@ -23,6 +23,7 @@ import CarouselTopTitles from '@src/components/carousel/variants/carousel-top-ti
 import CarouselCreators from '@src/components/carousel/variants/carousel-creators.tsx';
 import { useResponsive } from '@src/hooks/use-responsive.ts';
 import { useSelector } from 'react-redux';
+import { filterHiddenProfiles } from '@src/utils/profile';
 
 // ----------------------------------------------------------------------
 
@@ -60,9 +61,12 @@ export default function ExploreView() {
   });
 
   // FilteredCompletedProfiles is an array of objects, each object has a metadata property and inside exists a displayName en bio property; filter the profiles that not have a displayName and bio property
-  const filteredProfiles = latestCreatedProfiles?.filter(
+  const filtered = latestCreatedProfiles?.filter(
     (profile: any) => profile.metadata?.displayName && profile.metadata?.bio
   );
+
+  // Clear ###HIDDEN### profiles
+  const filteredProfiles = filterHiddenProfiles(filtered);
 
   const { data: explorePublications } = useExplorePublications({
     where: {

--- a/src/sections/finance/components/finance-earn-tokens.tsx
+++ b/src/sections/finance/components/finance-earn-tokens.tsx
@@ -23,7 +23,8 @@ const FinanceEarnTokens: FC<FinanceEarnTokensProps> = ({ sx, lgUp, ...other }) =
   const theme = useTheme();
 
   const handleClick = () => {
-    window.open('https://tropee.com/watchit', '_BLANK');
+    // TODO move to envs
+    window.open('https://zealy.io/cw/watchit', '_BLANK');
   };
 
   return (

--- a/src/sections/finance/components/finance-quick-transfer.tsx
+++ b/src/sections/finance/components/finance-quick-transfer.tsx
@@ -44,7 +44,7 @@ export const MAX_POOL: number = 1000000000;
 interface Props extends CardProps {
   title?: string;
   subheader?: string;
-  list: Profile[] | undefined;
+  list: Profile[] | null | undefined;
 }
 
 export const isValidAddress = (address: string): boolean => {

--- a/src/sections/finance/index.tsx
+++ b/src/sections/finance/index.tsx
@@ -17,6 +17,7 @@ import Tab from '@mui/material/Tab';
 import Iconify from '@src/components/iconify';
 import { useResponsive } from '@src/hooks/use-responsive.ts';
 import FinanceEarnTokens from '@src/sections/finance/components/finance-earn-tokens.tsx';
+import {filterHiddenProfiles} from "@src/utils/profile.ts";
 
 // ----------------------------------------------------------------------
 
@@ -28,10 +29,13 @@ export default function OverviewBankingView() {
   const { transactions, loading } = useGetSmartWalletTransactions();
   const [widgetSeriesData, setWidgetSeriesData] = useState<{ x: string; y: number }[]>([]);
   const [percent, setPercent] = useState(0);
-  const { data: following } = useProfileFollowing({
+  const { data: results } = useProfileFollowing({
     // @ts-ignore
     for: sessionData?.profile?.id,
   });
+
+  // Filter hidden profiles(unwanted profiles) from the results
+  const following = filterHiddenProfiles(results);
 
   useEffect(() => {
     if (!transactions || loading) return;

--- a/src/sections/user/view/user-profile-view.tsx
+++ b/src/sections/user/view/user-profile-view.tsx
@@ -26,6 +26,7 @@ import Alert from '@mui/material/Alert';
 import { useIsPolicyAuthorized } from '@src/hooks/use-is-policy-authorized.ts';
 import { GLOBAL_CONSTANTS } from '@src/config-global.ts';
 import { Address } from 'viem';
+import {filterHiddenProfiles} from "@src/utils/profile.ts";
 
 // ----------------------------------------------------------------------
 
@@ -76,13 +77,13 @@ const UserProfileView = ({ id }: any) => {
 
   useEffect(() => {
     if (profile) {
-      dispatch(setFollowers(followers ?? []));
+      dispatch(setFollowers(filterHiddenProfiles(followers) ?? []));
     }
   }, [profile, followers, dispatch]);
 
   useEffect(() => {
     if (profile) {
-      dispatch(setFollowings(following ?? []));
+      dispatch(setFollowings(filterHiddenProfiles(following) ?? []));
     }
   }, [profile, following, dispatch]);
 

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,5 +1,5 @@
 import { profile as profileBuilder, MetadataAttributeType } from '@lens-protocol/metadata';
-import { ProfileData } from '@src/auth/context/lens/types';
+import { ProfileData } from '@src/auth/context/web3Auth/types';
 import {Profile} from "@lens-protocol/api-bindings";
 
 const removeEmptyValues = (obj: any): any =>

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,5 +1,6 @@
 import { profile as profileBuilder, MetadataAttributeType } from '@lens-protocol/metadata';
 import { ProfileData } from '@src/auth/context/lens/types';
+import {Profile} from "@lens-protocol/api-bindings";
 
 const removeEmptyValues = (obj: any): any =>
   Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== '' && v !== null));
@@ -36,4 +37,25 @@ export const buildProfileMetadata = (
   const cleanedMetadata = removeEmptyValues(metadata);
 
   return profileBuilder(cleanedMetadata);
+};
+
+/**
+ * Filters an array of profiles to exclude any profiles with hidden indicators.
+ *
+ * This function removes profiles that have a "displayName" or "bio" property containing
+ * the substring '###HIDDEN###'. Any profiles containing this substring in either property are excluded
+ * from the returned array.
+ *
+ * @param {Profile[]} profiles - The array of profile objects to filter.
+ * @return {any[]} An array of filtered profiles excluding those marked as hidden.
+ */
+export const filterHiddenProfiles = (profiles?: Profile[]): Profile[] | null | undefined => {
+  // displayName, bio and lens id properties are checked for the hidden indicator
+  const patterns = ['###HIDDEN###'];
+
+  // Filter profiles that do not contain the hidden indicator in the "displayName" or "bio" properties using the patterns array
+  return profiles?.filter((profile: Profile) => !patterns.some((pattern) => profile?.metadata?.displayName?.includes(pattern) || profile?.metadata?.bio?.includes(pattern) || profile?.id.includes(pattern)));
+
+  // @ts-ignore
+  //return profiles.filter((profile) => !profile?.metadata?.displayName?.includes('###HIDDEN###') && !profile?.metadata?.bio.includes('###HIDDEN###'));
 };

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -40,14 +40,11 @@ export const buildProfileMetadata = (
 };
 
 /**
- * Filters an array of profiles to exclude any profiles with hidden indicators.
+ * Filters out profiles that contain a specific hidden indicator in their "displayName", "bio", or "id" properties.
  *
- * This function removes profiles that have a "displayName" or "bio" property containing
- * the substring '###HIDDEN###'. Any profiles containing this substring in either property are excluded
- * from the returned array.
- *
- * @param {Profile[]} profiles - The array of profile objects to filter.
- * @return {any[]} An array of filtered profiles excluding those marked as hidden.
+ * @param {Profile[]} [profiles] - An optional array of Profile objects to be filtered.
+ * @returns {Profile[] | null | undefined} An array of profiles excluding those with hidden indicators,
+ *                                         or `null`/`undefined` if the input is `null`/`undefined`.
  */
 export const filterHiddenProfiles = (profiles?: Profile[]): Profile[] | null | undefined => {
   // displayName, bio and lens id properties are checked for the hidden indicator
@@ -55,7 +52,4 @@ export const filterHiddenProfiles = (profiles?: Profile[]): Profile[] | null | u
 
   // Filter profiles that do not contain the hidden indicator in the "displayName" or "bio" properties using the patterns array
   return profiles?.filter((profile: Profile) => !patterns.some((pattern) => profile?.metadata?.displayName?.includes(pattern) || profile?.metadata?.bio?.includes(pattern) || profile?.id.includes(pattern)));
-
-  // @ts-ignore
-  //return profiles.filter((profile) => !profile?.metadata?.displayName?.includes('###HIDDEN###') && !profile?.metadata?.bio.includes('###HIDDEN###'));
 };

--- a/src/utils/test/profile.test.tsx
+++ b/src/utils/test/profile.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildProfileMetadata, filterHiddenProfiles } from '@src/utils/profile';
+import { ProfileData } from '@src/auth/context/web3Auth/types';
+import { Profile } from '@lens-protocol/api-bindings';
+import {ProfileId} from "@lens-protocol/react-web";
+import {URI} from "@lens-protocol/react";
+
+describe('testing buildProfileMetadata', () => {
+  it('returns metadata object with cleaned social links', () => {
+    const data: ProfileData = {
+      backgroundImage: null, profileImage: null, username: "cswni",
+      name: 'Cswni Inc',
+      bio: 'Developer',
+      socialLinks: { twitter: '_cswni', instagram: '', orb: '', farcaster: '' }
+    };
+    const profileImageURI = 'http://example.com/profile.jpg';
+    const backgroundImageURI = 'http://example.com/background.jpg';
+
+    const result = buildProfileMetadata(data, profileImageURI, backgroundImageURI);
+
+    expect(result).toEqual({
+      $schema: "https://json-schemas.lens.dev/profile/2.0.0.json",
+      lens: {
+        id: expect.any(String),
+        name: 'Cswni Inc',
+        bio: 'Developer',
+        picture: 'http://example.com/profile.jpg',
+        coverPicture: 'http://example.com/background.jpg',
+        attributes: [{ key: 'twitter', value: '_cswni', type: 'String' }],
+      },
+    });
+  });
+
+  it('removes empty values from metadata object', () => {
+    const data: ProfileData = {
+      backgroundImage: null, profileImage: null, username: "cswni",
+      name: '',
+      bio: 'null',
+      socialLinks: { twitter: '', farcaster: '', orb: '', instagram: '' }
+    };
+
+    const result = buildProfileMetadata(data);
+
+    expect(result).toEqual({
+      $schema: "https://json-schemas.lens.dev/profile/2.0.0.json",
+      lens: {
+        id: expect.any(String),
+        bio: 'null',
+      },
+    });
+  });
+});
+
+const profile = {
+  id: '0x0555' as ProfileId,
+  metadata: {
+    displayName: '###HIDDEN###',
+    bio: 'Developer',
+    picture: null,
+    coverPicture: null,
+    appId: null,
+    rawURI: 'https://uri.com' as URI,
+    attributes: null,
+    __typename: 'ProfileMetadata'
+  },
+  __typename: 'Profile',
+  invitedBy: null,
+  txHash: '',
+  createdAt: '',
+} as Partial<Profile>;
+
+
+describe('testing filterHiddenProfiles', () => {
+  it('filters out profiles with hidden indicators', () => {
+    const profiles = [
+      {
+        ...profile,
+        id: '1',
+        metadata: {
+          ...profile.metadata,
+          displayName: '###HIDDEN###',
+          bio: 'Developer',
+        },
+      },
+      {
+        ...profile,
+        id: '2',
+        metadata: {
+          ...profile.metadata,
+          displayName: 'demo',
+          bio: '###HIDDEN###',
+        },
+      },
+      {
+        ...profile,
+        id: '3',
+        metadata: {
+          ...profile.metadata,
+          displayName: 'Carlos Perez',
+          bio: 'Developer',
+        },
+      },
+    ];
+
+    const result = filterHiddenProfiles(profiles as Profile[]);
+
+    expect(result).toEqual([
+      {
+        ...profile,
+        id: '3',
+        metadata: {
+          ...profile.metadata,
+          displayName: 'Carlos Perez',
+          bio: 'Developer',
+        },
+      },
+    ]);
+  });
+
+  it('returns undefined if input is undefined', () => {
+    const result = filterHiddenProfiles(undefined);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns empty array if filtered all profiles', () => {
+    const result = filterHiddenProfiles([profile] as Profile[]);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => {
         authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
       }),
       codecovVitePlugin({
-        bundleName: "WatchItDev/watchit-app",
+        bundleName: "watchit-app",
         enableBundleAnalysis: process.env.VITE_CODECOV_TOKEN !== undefined,
         uploadToken: process.env.VITE_CODECOV_TOKEN,
       }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,15 +22,15 @@ export default defineConfig(({ mode }) => {
         project: "watchit-app",
         authToken: process.env.VITE_SENTRY_AUTH_TOKEN,
       }),
-      codecovVitePlugin({
-        bundleName: "watchit-app",
-        enableBundleAnalysis: process.env.VITE_CODECOV_TOKEN !== undefined,
-        uploadToken: process.env.VITE_CODECOV_TOKEN,
-      }),
       nodePolyfills({
         // To add only specific polyfills, add them here. If no option is passed, adds all polyfills
         include: ['process', "module", "buffer"],
         globals: { global: true, process: true, Buffer: true },
+      }),
+      codecovVitePlugin({
+        bundleName: "watchit-app",
+        enableBundleAnalysis: process.env.VITE_CODECOV_TOKEN !== undefined,
+        uploadToken: process.env.VITE_CODECOV_TOKEN,
       }),
     ],
     resolve: {


### PR DESCRIPTION
This pull request includes significant updates to the codebase, primarily focusing on the introduction of a new utility function to filter hidden profiles and various improvements to workflows and documentation.

### Utility Function for Filtering Hidden Profiles:

* [`src/utils/profile.ts`](diffhunk://#diff-7e67c4154b8f146474a1835168099845449ba0a8752233e9929b51a243b4ed98R41-R61): Added a new function `filterHiddenProfiles` to exclude profiles with hidden indicators in their `displayName`, `bio`, or `id` properties.

### Integration of the New Utility Function:

* [`src/components/login-modal/profile-select-view.tsx`](diffhunk://#diff-013ed6eed3051cc3ec2829748bdcc81698ed252ddc3fbef9bc69cfb257be1b52L57-R58): Updated the profile selection logic to use `filterHiddenProfiles` when setting profiles.
* [`src/layouts/_common/searchbar/searchbar.tsx`](diffhunk://#diff-2df78988a4cff97e3de512dee5871400ab42998c0aea8530807378a0e5bab4b4L66-R71): Applied `filterHiddenProfiles` to the search results to filter out hidden profiles.
* [`src/sections/explore/view.tsx`](diffhunk://#diff-179f0db64727965729b0e4e4022e46ebf9a5a1a7f3d7d4b1663ee7685cba0c72L63-R70): Used `filterHiddenProfiles` to clean up hidden profiles in the explore view.
* [`src/sections/finance/index.tsx`](diffhunk://#diff-ca6e93ca4e5927fd61f0b496d3850dde2ed36cb94f04510235657496668bde48L31-R39): Integrated `filterHiddenProfiles` to filter out hidden profiles from the following list.
* [`src/sections/user/view/user-profile-view.tsx`](diffhunk://#diff-a83821f9b603e06dc82fc334d31ac95eb7c86a9ee6b7e0e1ea20fb10f8f6a199L79-R86): Applied `filterHiddenProfiles` to followers and following lists in the user profile view.