### PR TITLE
fix: correct conditional checks for form helper texts during updating profile metadata

### DIFF
--- a/src/components/login-modal/profile-form-view.tsx
+++ b/src/components/login-modal/profile-form-view.tsx
@@ -489,7 +489,7 @@ export const ProfileFormView: React.FC<ProfileFormProps> = ({
               onBlur={formik.handleBlur}
               disabled={loading}
               error={formik.touched.name && Boolean(formik.errors.name)}
-              helperText={formik.touched.name ? formik.errors.name : 'e.g., John Doe'}
+              helperText={formik.touched.name && formik.errors.name ? formik.errors.name : 'e.g., John Doe'}
             />
           </Grid>
           <Grid item xs={12} sm={6}>
@@ -508,7 +508,7 @@ export const ProfileFormView: React.FC<ProfileFormProps> = ({
               }}
               onBlur={formik.handleBlur}
               error={formik.touched.username && Boolean(formik.errors.username)}
-              helperText={formik.touched.username ? formik.errors.username : 'e.g., johndoe123'}
+              helperText={formik.touched.username && formik.errors.userName ? formik.errors.username : 'e.g., johndoe123'}
             />
           </Grid>
         </Grid>
@@ -528,7 +528,7 @@ export const ProfileFormView: React.FC<ProfileFormProps> = ({
           rows={4}
           sx={{ mt: 2 }}
           error={formik.touched.bio && Boolean(formik.errors.bio)}
-          helperText={formik.touched.bio ? formik.errors.bio : 'Share something about yourself'}
+          helperText={formik.touched.bio && formik.errors.bio ? formik.errors.bio : 'Share something about yourself'}
         />
 
         {/* Link Social Networks */}


### PR DESCRIPTION
This pull request includes updates to the `ProfileFormView` component in the `src/components/login-modal/profile-form-view.tsx` file to improve form validation and error handling. The changes ensure that helper text is only displayed when there are both touched fields and corresponding errors.

Improvements to form validation and error handling:

* Modified the `helperText` property for the `name` field to ensure it only displays when both `formik.touched.name` and `formik.errors.name` are true.
* Corrected the `helperText` property for the `username` field to check `formik.errors.username` instead of `formik.errors.userName` and ensure it only displays when both `formik.touched.username` and `formik.errors.username` are true.
* Modified the `helperText` property for the `bio` field to ensure it only displays when both `formik.touched.bio` and `formik.errors.bio` are true.

When click in update button the helpers texts gone(due to a lack validations) causing a the elements move up)

![image](https://github.com/user-attachments/assets/cd30b529-f304-4831-ac9d-ae30fa49476f)


