### PR TITLE
fix: adjust comment item spacing and padding for better layout

### DIFF
--- a/src/sections/publication/components/publication-comment-item.tsx
+++ b/src/sections/publication/components/publication-comment-item.tsx
@@ -232,7 +232,7 @@ const PublicationCommentItem:FC<PublicationCommentItemProps> = (props) => {
             }}
           >
             <Stack
-              sx={{ mb: 0.5, p: 1 }}
+              sx={{ mb: 0.5, px: 1, py: 0.5 }}
               alignItems={{ sm: 'center' }}
               justifyContent="flex-start"
               direction={'row'}
@@ -244,7 +244,7 @@ const PublicationCommentItem:FC<PublicationCommentItemProps> = (props) => {
               </Box>
             </Stack>
 
-            <Box sx={{ typography: 'body2', color: 'text.secondary', p: 1 }}>
+            <Box sx={{ typography: 'body2', color: 'text.secondary', p: 1, mt: -1.5 }}>
               {comment?.metadata?.content}
             </Box>
           </ContentContainer>


### PR DESCRIPTION
- Updated `Stack` in `publication-comment-item.tsx` to use `px: 1` and `py: 0.5` for precise padding control.
- Added `mt: -1.5` to `Box` for improved vertical spacing between content elements. These changes enhance the visual alignment and readability of comments.

![image](https://github.com/user-attachments/assets/8f68a1ea-b63a-463d-8e46-92b8bcc4d5cf)
