### PR TITLE
refactor: limit profile creation and clear bookmarks on profile login and improve types

### DIFF
--- a/src/components/login-modal/profile-select-view.tsx
+++ b/src/components/login-modal/profile-select-view.tsx
@@ -19,6 +19,7 @@ import { UserItem } from '@src/components/user-item';
 import { useAuth } from '@src/hooks/use-auth.ts';
 import { ERRORS } from '@src/libs/notifications/errors.ts';
 import {ProfileSelectionProps} from "@src/components/login-modal/types.ts"
+import { clearBookmarks } from '@src/redux/bookmark';
 
 // ----------------------------------------------------------------------
 
@@ -61,6 +62,8 @@ export const ProfileSelectView: React.FC<ProfileSelectionProps> = ({
       await login(profile);
       dispatch(setAuthLoading({ isSessionLoading: false }));
     }
+    // Clear all bookmarks
+    dispatch(clearBookmarks());
   };
 
   return (
@@ -109,11 +112,8 @@ export const ProfileSelectView: React.FC<ProfileSelectionProps> = ({
                 fontWeight: 'bold',
               }}
             >
-              Please select one profile
+              Select your profile
             </Typography>
-            <Button variant="outlined" onClick={onRegisterNewProfile} sx={{ p: 1, width: '40%' }}>
-              New profile
-            </Button>
           </Box>
           <Box sx={{ maxHeight: '600px', overflowY: 'auto', overflow: 'auto' }}>
             <List

--- a/src/components/login-modal/types.ts
+++ b/src/components/login-modal/types.ts
@@ -1,12 +1,13 @@
 import {LoginError} from "@lens-protocol/react-web"
 import {Profile} from "@lens-protocol/api-bindings"
+import {URI} from "@lens-protocol/react"
 
 export interface ProfileFormInitialValuesProps {
   username: string,
   name: string,
   bio: string,
-  profileImage: null,
-  backgroundImage: null,
+  profileImage: URI | null | undefined,
+  backgroundImage: URI | null | undefined,
   socialLinks: {
     twitter: string,
     instagram: string,

--- a/src/redux/bookmark/index.ts
+++ b/src/redux/bookmark/index.ts
@@ -43,9 +43,14 @@ const bookmarkSlice = createSlice({
         );
       }
     },
+
+    // Remove all bookmarks
+    clearBookmarks: (state) => {
+      state.bookmarkPublications = [];
+    },
   },
 });
 
-export const { addBookmark, removeBookmark } = bookmarkSlice.actions;
+export const { addBookmark, removeBookmark, clearBookmarks } = bookmarkSlice.actions;
 
 export default bookmarkSlice.reducer;


### PR DESCRIPTION
- **login-modal/profile-select-view.tsx**:
  - Dispatch `clearBookmarks` action during profile login to reset bookmarks.
  - Updated profile selection text for better clarity.
  - Removed unused "New profile" button for improved UI simplification and avoid user can create several profles.

- **redux/bookmark/index.ts**:
  - Added `clearBookmarks` action to remove all stored bookmarks and updated exports accordingly.

- **login-modal/types.ts**:
  - Enhanced `ProfileFormInitialValuesProps` to support `URI` type for image fields.