### PR TITLE
test(components): add unit tests for CopyableText component

### DIFF
--- a/src/components/copyable-text/__test__/__snapshots__/copyable-text.test.tsx.snap
+++ b/src/components/copyable-text/__test__/__snapshots__/copyable-text.test.tsx.snap
@@ -1,0 +1,32 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[COMPONENTS]: CopyableText component testing > to match snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiStack-root css-1d9cypr-MuiStack-root"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-169yplb-MuiTypography-root"
+      >
+        Test Label
+      </p>
+      <button
+        aria-label="Copy"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-n2gp7e-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element="true"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          data-icon="mdi:content-copy"
+          data-testid="icon"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/copyable-text/__test__/copyable-text.test.tsx
+++ b/src/components/copyable-text/__test__/copyable-text.test.tsx
@@ -1,0 +1,69 @@
+import { render, fireEvent } from '@testing-library/react';
+import CopyableText from '@src/components/copyable-text/copyable-text';
+import { Icon } from '@iconify/react';
+
+const mockClipboard = {
+  writeText: vi.fn()
+};
+Object.defineProperty(navigator, 'clipboard', { value: mockClipboard });
+
+vi.mock('@iconify/react', () => ({
+  Icon: vi.fn(({ icon }) => <span data-testid="icon" data-icon={icon} />)
+}));
+
+vi.useFakeTimers();
+
+describe('[COMPONENTS]: CopyableText component testing', () => {
+  it('to match snapshot', () => {
+    const { baseElement } = render(<CopyableText label="Test Label" text="Test Text" />);
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('renders label correctly', () => {
+    const { getByText } = render(<CopyableText label="Test Label" text="Test Text" />);
+    expect(getByText('Test Label')).toBeInTheDocument();
+  });
+
+  it('copies text to clipboard when button is clicked', () => {
+    const { getByRole } = render(<CopyableText label="Test Label" text="Text to copy" />);
+    const copyButton = getByRole('button');
+
+    fireEvent.click(copyButton);
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith('Text to copy');
+  });
+
+  it('shows copy icon by default', () => {
+    render(<CopyableText label="Test Label" text="Test Text" />);
+    expect(Icon).toHaveBeenCalledWith(expect.objectContaining({ icon: 'mdi:content-copy' }), expect.anything());
+  });
+
+  it('shows check icon after copying', () => {
+    render(<CopyableText label="Test Label" text="Test Text" />);
+
+    // @ts-expect-error No error in this context
+    Icon.mockClear();
+
+    const copyButton = document.querySelector('button');
+    // @ts-expect-error No error in this context
+    fireEvent.click(copyButton);
+
+    expect(Icon).toHaveBeenCalledWith(expect.objectContaining({ icon: 'mdi:check' }), expect.anything());
+  });
+
+  it('renders tooltip with correct copy text', () => {
+    const { getByRole } = render(<CopyableText label="Test Label" text="Test Text" />);
+    const copyButton = getByRole('button');
+
+    expect(copyButton).toHaveAttribute('aria-label', 'Copy');
+  });
+
+  it('updates tooltip text after copying', () => {
+    const { getByRole } = render(<CopyableText label="Test Label" text="Test Text" />);
+    const copyButton = getByRole('button');
+
+    fireEvent.click(copyButton);
+
+    expect(copyButton).toHaveAttribute('aria-label', 'Copied!');
+  });
+});


### PR DESCRIPTION
- Add snapshot test in `copyable-text.test.tsx.snap` to ensure consistent rendering.
- Add unit tests in `copyable-text.test.tsx`:
  - Test rendering of the label and default copy icon.
  - Test clipboard write functionality on button click.
  - Verify icon update after copying.
  - Check tooltip behavior before and after copy action.