### PR TITLE
test(components): add unit tests for CustomBreadcrumbs

### DIFF
--- a/src/components/custom-breadcrumbs/__test__/__snapshots__/custom-breadcrumbs.test.tsx.snap
+++ b/src/components/custom-breadcrumbs/__test__/__snapshots__/custom-breadcrumbs.test.tsx.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[COMPONENTS]: CustomBreadcrumbs component testing > to match snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiStack-root css-1d9cypr-MuiStack-root"
+      >
+        <div
+          class="MuiBox-root css-i9gxme"
+        >
+          <nav
+            class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-63vwl1-MuiTypography-root-MuiBreadcrumbs-root"
+          >
+            <ol
+              class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
+            >
+              <li
+                class="MuiBreadcrumbs-li"
+              >
+                <div
+                  data-disabled="false"
+                  data-link="Home"
+                  data-testid="link-item"
+                >
+                  Home
+                </div>
+              </li>
+              <li
+                aria-hidden="true"
+                class="MuiBreadcrumbs-separator css-1wuw8dw-MuiBreadcrumbs-separator"
+              >
+                <span
+                  class="MuiBox-root css-1bi6evy"
+                />
+              </li>
+              <li
+                class="MuiBreadcrumbs-li"
+              >
+                <div
+                  data-disabled="true"
+                  data-link="Dashboard"
+                  data-testid="link-item"
+                >
+                  Dashboard
+                </div>
+              </li>
+            </ol>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/custom-breadcrumbs/__test__/__snapshots__/link-item.test.tsx.snap
+++ b/src/components/custom-breadcrumbs/__test__/__snapshots__/link-item.test.tsx.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[COMPONENTS]: BreadcrumbsLink component testing > to match snapshot 1`] = `
+<body>
+  <div>
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-133mjyt-MuiTypography-root-MuiLink-root"
+      data-testid="router-link"
+      href="/dashboard"
+    >
+      Dashboard
+    </a>
+  </div>
+</body>
+`;

--- a/src/components/custom-breadcrumbs/__test__/__snapshots__/types.test.ts.snap
+++ b/src/components/custom-breadcrumbs/__test__/__snapshots__/types.test.ts.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`[TYPES]: Breadcrumbs types testing > to match snapshot 1`] = `
+{
+  "sampleBreadcrumbs": {
+    "action": <button>
+      Action
+    </button>,
+    "activeLast": true,
+    "heading": "Page Title",
+    "links": [
+      {
+        "href": "/",
+        "name": "Home",
+      },
+      {
+        "href": "/dashboard",
+        "name": "Dashboard",
+      },
+    ],
+    "moreLink": [
+      "https://example.com",
+    ],
+  },
+  "sampleLink": {
+    "href": "/dashboard",
+    "icon": <span>
+      🏠
+    </span>,
+    "name": "Dashboard",
+  },
+}
+`;

--- a/src/components/custom-breadcrumbs/__test__/custom-breadcrumbs.test.tsx
+++ b/src/components/custom-breadcrumbs/__test__/custom-breadcrumbs.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import CustomBreadcrumbs from '../custom-breadcrumbs';
+import LinkItem from '../link-item';
+import {afterEach} from "vitest"
+
+// Mock LinkItem component to simplify testing
+vi.mock('../link-item', () => ({
+  default: vi.fn(({ link, activeLast, disabled }) => (
+    <div data-testid="link-item" data-link={link.name} data-active-last={activeLast} data-disabled={disabled}>
+      {link.name}
+    </div>
+  ))
+}));
+
+describe('[COMPONENTS]: CustomBreadcrumbs component testing', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  })
+
+  it('to match snapshot', () => {
+    const { baseElement } = render(
+      <CustomBreadcrumbs
+        links={[
+          { name: 'Home', href: '/' },
+          { name: 'Dashboard', href: '/dashboard' }
+        ]}
+      />
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+  it('does not render breadcrumbs when links array is empty', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[]}
+        heading="Page Title"
+      />
+    );
+
+    expect(LinkItem).not.toHaveBeenCalled();
+  });
+
+
+
+  it('renders heading when provided', () => {
+    render(
+      <CustomBreadcrumbs
+        heading="Page Title"
+        links={[{ name: 'Home', href: '/' }]}
+      />
+    );
+    expect(screen.getByText('Page Title')).toBeInTheDocument();
+  });
+
+  it('renders breadcrumbs from links array', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[
+          { name: 'Home', href: '/' },
+          { name: 'Dashboard', href: '/dashboard' }
+        ]}
+      />
+    );
+
+    /*expect(LinkItem).toHaveBeenCalledTimes(2);*/
+    expect(screen.getAllByTestId('link-item')).toHaveLength(2);
+  });
+
+  it('marks the last link as disabled', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[
+          { name: 'Home', href: '/' },
+          { name: 'Dashboard', href: '/dashboard' }
+        ]}
+      />
+    );
+
+    const linkItems = screen.getAllByTestId('link-item');
+    expect(linkItems[0]).toHaveAttribute('data-disabled', 'false');
+    expect(linkItems[1]).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('renders action element when provided', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[{ name: 'Home', href: '/' }]}
+        action={<button>Action Button</button>}
+      />
+    );
+
+    expect(screen.getByText('Action Button')).toBeInTheDocument();
+  });
+
+  it('renders additional links from moreLink', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[{ name: 'Home', href: '/' }]}
+        moreLink={['https://example.com/docs', 'https://example.com/help']}
+      />
+    );
+
+    expect(screen.getByText('https://example.com/docs')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/help')).toBeInTheDocument();
+  });
+
+  it('does not render heading when not provided', () => {
+    render(
+      <CustomBreadcrumbs
+        links={[{ name: 'Home', href: '/' }]}
+      />
+    );
+
+    const headings = screen.queryAllByRole('heading');
+    expect(headings.length).toBe(0);
+  });
+
+  it('does not render moreLink section when not provided', () => {
+    const { container } = render(
+      <CustomBreadcrumbs
+        links={[{ name: 'Home', href: '/' }]}
+      />
+    );
+
+    // Check that there are no links other than those in the breadcrumbs
+    const links = container.querySelectorAll('a[href]');
+    expect(links.length).toBe(0);
+  });
+
+  it('passes custom sx prop to container', () => {
+    const { container } = render(
+      <CustomBreadcrumbs
+        links={[{ name: 'Home', href: '/' }]}
+        sx={{ padding: '20px' }}
+      />
+    );
+
+    const box = container.firstChild;
+    expect(box).toHaveStyle('padding: 20px');
+  });
+});

--- a/src/components/custom-breadcrumbs/__test__/link-item.test.tsx
+++ b/src/components/custom-breadcrumbs/__test__/link-item.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react';
+import BreadcrumbsLink from '../link-item';
+
+// Mock the RouterLink component
+vi.mock('@src/routes/components', () => {
+  const React = require('react');
+  return {
+    // @ts-expect-error No error in this context
+    RouterLink: React.forwardRef(({ href, children, ...props }, ref) => (
+      <a href={href} ref={ref} data-testid="router-link" {...props}>
+        {children}
+      </a>
+    )),
+  };
+});
+
+describe('[COMPONENTS]: BreadcrumbsLink component testing', () => {
+  it('to match snapshot', () => {
+    const { baseElement } = render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard', href: '/dashboard' }}
+        disabled={false}
+      />
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('passes proper props to RouterLink component', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Settings', href: '/settings' }}
+        disabled={false}
+      />
+    );
+
+    const link = screen.getByTestId('router-link');
+    expect(link).toHaveAttribute('href', '/settings');
+    expect(link).toHaveStyle('color: rgba(0, 0, 0, 0.87)'); // text.primary
+  });
+
+  it('renders link with href using RouterLink component', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard', href: '/dashboard' }}
+        disabled={false}
+      />
+    );
+
+    const link = screen.getByTestId('router-link');
+    expect(link).toHaveAttribute('href', '/dashboard');
+    expect(link).toHaveTextContent('Dashboard');
+  });
+
+  it('renders as Box component when no href is provided', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard' }}
+        disabled={false}
+      />
+    );
+
+    expect(screen.queryByTestId('router-link')).not.toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    const TestIcon = () => <span data-testid="test-icon">Icon</span>;
+
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard', icon: <TestIcon /> }}
+        disabled={false}
+      />
+    );
+
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('applies disabled styles when disabled is true and activeLast is false', () => {
+    const { container } = render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard' }}
+        disabled={true}
+        activeLast={false}
+      />
+    );
+
+    const element = container.firstChild;
+    expect(element).toHaveStyle('pointer-events: none');
+    expect(element).toHaveStyle('cursor: default');
+  });
+
+  it('does not apply disabled styles when disabled is true but activeLast is true', () => {
+    const { container } = render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard' }}
+        disabled={true}
+        activeLast={true}
+      />
+    );
+
+    const element = container.firstChild;
+    expect(element).not.toHaveStyle('pointer-events: none');
+  });
+
+  it('displays name correctly', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Very Long Dashboard Name' }}
+        disabled={false}
+      />
+    );
+
+    expect(screen.getByText('Very Long Dashboard Name')).toBeInTheDocument();
+  });
+
+  it('renders icon with correct margin styling', () => {
+    const TestIcon = () => <svg data-testid="svg-icon" />;
+
+    const { container } = render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard', icon: <TestIcon /> }}
+        disabled={false}
+      />
+    );
+
+    const iconContainer = container.querySelector('span');
+    expect(iconContainer).toHaveStyle('margin-right: 8px');
+  });
+
+  it('handles empty name gracefully', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: '' }}
+        disabled={false}
+      />
+    );
+
+    expect(document.body).toContainHTML('<div');
+  });
+
+  it('renders RouterLink with proper ref handling', () => {
+    render(
+      <BreadcrumbsLink
+        link={{ name: 'Dashboard', href: '/dashboard' }}
+        disabled={false}
+      />
+    );
+
+    const link = screen.getByTestId('router-link');
+    expect(link).toBeInTheDocument();
+  });
+});

--- a/src/components/custom-breadcrumbs/__test__/types.test.ts
+++ b/src/components/custom-breadcrumbs/__test__/types.test.ts
@@ -1,0 +1,97 @@
+import React from 'react'
+import { BreadcrumbsLinkProps, CustomBreadcrumbsProps } from '../types';
+
+describe('[TYPES]: Breadcrumbs types testing', () => {
+  it('to match snapshot', () => {
+    const sampleLink: BreadcrumbsLinkProps = {
+      name: 'Dashboard',
+      href: '/dashboard',
+      icon: React.createElement('span', null, '🏠'),
+    };
+
+    const sampleBreadcrumbs: CustomBreadcrumbsProps = {
+      heading: 'Page Title',
+      links: [
+        { name: 'Home', href: '/' },
+        { name: 'Dashboard', href: '/dashboard' },
+      ],
+      activeLast: true,
+      moreLink: ['https://example.com'],
+      action: React.createElement('button', null, 'Action'),
+    };
+
+    expect({ sampleLink, sampleBreadcrumbs }).toMatchSnapshot();
+  });
+
+  it('creates valid BreadcrumbsLinkProps with all properties', () => {
+    const link: BreadcrumbsLinkProps = {
+      name: 'Settings',
+      href: '/settings',
+      icon: React.createElement('span', null, '⚙️'),
+    };
+
+    expect(link).toHaveProperty('name', 'Settings');
+    expect(link).toHaveProperty('href', '/settings');
+    expect(link).toHaveProperty('icon');
+  });
+
+  it('creates valid BreadcrumbsLinkProps with only required properties', () => {
+    // All properties are optional in BreadcrumbsLinkProps
+    const minimalLink: BreadcrumbsLinkProps = {};
+    expect(minimalLink).toEqual({});
+  });
+
+  it('creates valid CustomBreadcrumbsProps with all properties', () => {
+    const breadcrumbs: CustomBreadcrumbsProps = {
+      heading: 'Users',
+      links: [
+        { name: 'Home', href: '/' },
+        { name: 'Users', href: '/users' },
+      ],
+      activeLast: true,
+      moreLink: ['https://docs.example.com/users'],
+      action: React.createElement('button', null, 'Add user'),
+      sx: { marginBottom: 2 }
+    };
+
+    expect(breadcrumbs).toHaveProperty('heading', 'Users');
+    expect(breadcrumbs).toHaveProperty('links');
+    expect(breadcrumbs.links).toHaveLength(2);
+    expect(breadcrumbs).toHaveProperty('activeLast', true);
+    expect(breadcrumbs).toHaveProperty('moreLink');
+    expect(breadcrumbs).toHaveProperty('action');
+    expect(breadcrumbs).toHaveProperty('sx');
+  });
+
+  it('creates valid CustomBreadcrumbsProps with only required properties', () => {
+    const minimalBreadcrumbs: CustomBreadcrumbsProps = {
+      links: [{ name: 'Home', href: '/' }],
+    };
+
+    expect(minimalBreadcrumbs).toHaveProperty('links');
+    expect(minimalBreadcrumbs.links).toHaveLength(1);
+    expect(minimalBreadcrumbs.heading).toBeUndefined();
+    expect(minimalBreadcrumbs.activeLast).toBeUndefined();
+    expect(minimalBreadcrumbs.moreLink).toBeUndefined();
+    expect(minimalBreadcrumbs.action).toBeUndefined();
+  });
+
+  it('supports an array of strings for moreLink property', () => {
+    const breadcrumbs: CustomBreadcrumbsProps = {
+      links: [{ name: 'Home' }],
+      moreLink: ['https://example.com/docs', 'https://example.com/help'],
+    };
+
+    expect(Array.isArray(breadcrumbs.moreLink)).toBe(true);
+    expect(breadcrumbs.moreLink).toHaveLength(2);
+    expect(typeof breadcrumbs.moreLink![0]).toBe('string');
+  });
+
+  it('supports empty links array', () => {
+    const breadcrumbs: CustomBreadcrumbsProps = {
+      links: [],
+    };
+
+    expect(breadcrumbs.links).toEqual([]);
+  });
+});

--- a/src/components/custom-breadcrumbs/custom-breadcrumbs.tsx
+++ b/src/components/custom-breadcrumbs/custom-breadcrumbs.tsx
@@ -19,7 +19,7 @@ export default function CustomBreadcrumbs({
   sx,
   ...other
 }: CustomBreadcrumbsProps) {
-  const lastLink = links[links.length - 1].name;
+  const lastLink = links[links.length - 1]?.name;
 
   return (
     <Box sx={{ ...sx }}>


### PR DESCRIPTION
Added comprehensive test coverage for the `CustomBreadcrumbs` component:
- **custom-breadcrumbs.test.tsx**: Added snapshot and behavior tests for rendering links, actions, headings, and handling edge cases (e.g., empty arrays or missing links).
- **link-item.test.tsx**: Verified `BreadcrumbsLink` behavior through tests for props handling, styles, icons, and edge cases like inactive or undefined links.
- **types.test.ts**: Added tests for TypeScript typings, validated correct usage of `CustomBreadcrumbsProps` and `BreadcrumbsLinkProps` interfaces.

Includes snapshots for accurate visual regression tracking.