### PR TITLE
feat(dashboard): add keyboard support for "Escape" action

### DIFF
--- a/src/layouts/dashboard/header-content.tsx
+++ b/src/layouts/dashboard/header-content.tsx
@@ -1,17 +1,27 @@
-import Button from '@mui/material/Button';
+import { useEffect, FC } from 'react';
 import { IconChevronLeft } from '@tabler/icons-react';
+
+import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Label from '@src/components/label';
-import { FC } from 'react';
 import { useResponsive } from '@src/hooks/use-responsive.ts';
-
-interface HeaderContentProps {
-  handleBack?: () => void;
-  title?: string;
-}
+import { HeaderContentProps } from './types';
 
 const HeaderContent: FC<HeaderContentProps> = ({ handleBack, title }) => {
   const mdUp = useResponsive('up', 'md');
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && handleBack) {
+        handleBack();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleBack]);
 
   if (!mdUp) return <></>;
 

--- a/src/layouts/dashboard/types.ts
+++ b/src/layouts/dashboard/types.ts
@@ -1,0 +1,4 @@
+export interface HeaderContentProps {
+  handleBack?: () => void;
+  title?: string;
+}


### PR DESCRIPTION
- Created a new `HeaderContentProps` interface in `types.ts` to organize prop definitions.
- Updated `header-content.tsx`:
  - Added `useEffect` to listen for the "Escape" key press to trigger `handleBack`.
  - Refactored to use the new `HeaderContentProps` interface for props typing.