### PR TITLE
chore(lighthouse): add GitHub Actions workflow for weekly Lighthouse audits

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -1,0 +1,21 @@
+name: Lighthouse weekly
+
+on:
+  schedule:
+    - cron: "0 6 * * 5"
+  workflow_dispatch:
+
+jobs:
+  lhci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          urls: |
+            https://watchit.movie/
+          uploadArtifacts: true
+          configPath: .lighthouserc.json


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run Lighthouse CI weekly on Fridays at 06:00 UTC.
It also supports manual runs via workflow_dispatch.

- Audits the public URL https://watchit.movie/
- Uploads Lighthouse reports as artifacts (HTML and JSON)

This helps to automatically monitor performance, accessibility, SEO, and best practices over time.